### PR TITLE
Metrics name unification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY : build run fresh test clean
 
-BIN := awsdc-exporter
+BIN := aws-dc-exporter
 
 HASH := $(shell git rev-parse --short HEAD)
 COMMIT_DATE := $(shell git show -s --format=%ci ${HASH})

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY : build run fresh test clean
 
-BIN := aws-dc-exporter
+BIN := aws_dc_exporter
 
 HASH := $(shell git rev-parse --short HEAD)
 COMMIT_DATE := $(shell git show -s --format=%ci ${HASH})

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY : build run fresh test clean
 
-BIN := aws_dc_exporter
+BIN := awsdc-exporter
 
 HASH := $(shell git rev-parse --short HEAD)
 COMMIT_DATE := $(shell git show -s --format=%ci ${HASH})

--- a/exporter.go
+++ b/exporter.go
@@ -36,7 +36,7 @@ func (hub *Hub) Collect(m *metrics.Set, e Exporter) {
 		return
 	}
 	for _, c := range conn.Connections {
-		connectionMetricDesc := fmt.Sprintf(`%s_connections{job="%s",conn_state="%s",conn_name="%s",partner_name="%s",conn_id="%s",bandwidth="%s"}`, namespace, e.job.Name, *c.ConnectionState, *c.ConnectionName, *c.PartnerName, *c.ConnectionId, *c.Bandwidth)
+		connectionMetricDesc := fmt.Sprintf(`%s_connections{job="%s",conn_state="%s",conn_name="%s",conn_id="%s",bandwidth="%s"}`, namespace, e.job.Name, *c.ConnectionState, *c.ConnectionName, *c.ConnectionId, *c.Bandwidth)
 		connState := *c.ConnectionState
 		m.GetOrCreateGauge(connectionMetricDesc, func() float64 {
 			return stateToFloat(connState)

--- a/exporter.go
+++ b/exporter.go
@@ -36,7 +36,7 @@ func (hub *Hub) Collect(m *metrics.Set, e Exporter) {
 		return
 	}
 	for _, c := range conn.Connections {
-		connectionMetricDesc := fmt.Sprintf(`%s_connections{job="%s",conn_state="%s",conn_name="%s",conn_id="%s",bandwidth="%s"}`, namespace, e.job.Name, *c.ConnectionState, *c.ConnectionName, *c.ConnectionId, *c.Bandwidth)
+		connectionMetricDesc := fmt.Sprintf(`%s_connections{job="%s",connection_state="%s",connection_name="%s",connection_id="%s",bandwidth="%s",aws_logical_device="%s", location="%s"}`, namespace, e.job.Name, *c.ConnectionState, *c.ConnectionName, *c.ConnectionId, *c.Bandwidth, *c.AwsDeviceV2, *c.Location)
 		connState := *c.ConnectionState
 		m.GetOrCreateGauge(connectionMetricDesc, func() float64 {
 			return stateToFloat(connState)
@@ -51,7 +51,7 @@ func (hub *Hub) Collect(m *metrics.Set, e Exporter) {
 		return
 	}
 	for _, i := range interfaces.VirtualInterfaces {
-		interfacesMetricDesc := fmt.Sprintf(`%s_virtual_interfaces{job="%s",connection_id="%s",virt_interface_state="%s",virt_interface_name="%s",customer_address="%s",virt_interface_id="%s",location="%s"}`, namespace, e.job.Name, *i.ConnectionId, *i.VirtualInterfaceState, *i.VirtualInterfaceName, *i.CustomerAddress, *i.VirtualInterfaceId, *i.Location)
+		interfacesMetricDesc := fmt.Sprintf(`%s_virtual_interfaces{job="%s",connection_id="%s",virt_interface_state="%s",virt_interface_name="%s",customer_address="%s",virt_interface_id="%s",aws_logical_device="%s", location="%s"}`, namespace, e.job.Name, *i.ConnectionId, *i.VirtualInterfaceState, *i.VirtualInterfaceName, *i.CustomerAddress, *i.VirtualInterfaceId, *i.AwsDeviceV2, *i.Location)
 		intState := *i.VirtualInterfaceState
 		m.GetOrCreateGauge(interfacesMetricDesc, func() float64 {
 			return stateToFloat(intState)
@@ -59,7 +59,7 @@ func (hub *Hub) Collect(m *metrics.Set, e Exporter) {
 
 		// fetch list of bgpPeers and create metrics
 		for _, bgp := range i.BgpPeers {
-			bgpMetricDesc := fmt.Sprintf(`%s_bgp_peers{job="%s",virt_interface_id="%s",bgp_peer_id="%s",bgp_status="%s",bgp_peer_state="%s",aws_device_v2="%s"}`, namespace, e.job.Name, *i.VirtualInterfaceId, *bgp.BgpPeerId, *bgp.BgpStatus, *bgp.BgpPeerState, *bgp.AwsDeviceV2)
+			bgpMetricDesc := fmt.Sprintf(`%s_bgp_peers{job="%s",virt_interface_id="%s",virt_interface_name="%s",bgp_peer_id="%s",bgp_status="%s",bgp_peer_state="%s",aws_logical_device="%s",location="%s"}`, namespace, e.job.Name, *i.VirtualInterfaceId, *i.VirtualInterfaceName, *bgp.BgpPeerId, *bgp.BgpStatus, *bgp.BgpPeerState, *bgp.AwsDeviceV2, *i.Location)
 			bgpState := *bgp.BgpPeerState
 			m.GetOrCreateGauge(bgpMetricDesc, func() float64 {
 				return stateToFloat(bgpState)


### PR DESCRIPTION
Metrics name unification for Connections, Virtual interfaces and BGP peers. This was also done to unify with what it is called in the amazon web interface.
This was done to correctly display breadcrumbs in the Grafana dashboard.
Connection (connection_id) > Virtual Interface (connection_id + virtual_interface_id) > BGP Peer (virtual_interface_id + bgp_peer_id)
Also, I had to remove the partner_name tag, because if it is not filled in the amazon, then the exporter gives an error.